### PR TITLE
L1t 1063 emyr

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
@@ -537,7 +537,9 @@ L1TLayer1TaskInputsTask = cms.Task(
 
 L1TLayer1Task = cms.Task(
      l1tLayer1Barrel,
+     l1tLayer1BarrelExtended,
      l1tLayer1HGCal,
+     l1tLayer1HGCalExtended,
      l1tLayer1HGCalNoTK,
      l1tLayer1HF,
      l1tLayer1,

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1tPFTracksFromL1Tracks_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1tPFTracksFromL1Tracks_cfi.py
@@ -26,7 +26,7 @@ l1tPFTracksFromL1Tracks = cms.EDProducer("PFTrackProducerFromL1Tracks",
 )
 
 l1tPFTracksFromL1TracksExtended = l1tPFTracksFromL1Tracks.clone(
-    L1TrackTag = cms.InputTag("TTTracksFromExtendedTrackletEmulation", "Level1TTTracks"),
+    L1TrackTag = cms.InputTag("l1tTTTracksFromExtendedTrackletEmulation", "Level1TTTracks"),
     nParam = 5,
     qualityBits = cms.vstring( 
         "momentum.perp > 2 && getStubRefs.size >= 4 && chi2Red < 15 && POCA.x < 1.0 && POCA.x > -1.0 && POCA.y < 1.0 && POCA.y > -1.0",


### PR DESCRIPTION
#### PR description:

Add CTL1 producers that use the extended tracks into the task.  I think this change may have got lost between the original PR to the IB [here](https://github.com/cms-l1t-offline/cmssw/pull/1060/files#diff-5a1b615c1376e0679601d9203e1ad5445c070b9276c9ff6cc1f79b05fc70870eR537) and the rebased one 
[here](https://github.com/cms-l1t-offline/cmssw/pull/1063/files#diff-5a1b615c1376e0679601d9203e1ad5445c070b9276c9ff6cc1f79b05fc70870eR538).

Also updated the name of the extended track collection consumed by CTL1 producers.

#### PR validation:

Reran one of the failed RelVals, 20834.0.
